### PR TITLE
[FIO internal] dts: imx6ull-14x14-evk: drop imx6ul u-boot include

### DIFF
--- a/arch/arm/dts/imx6ull-14x14-evk.dts
+++ b/arch/arm/dts/imx6ull-14x14-evk.dts
@@ -6,7 +6,6 @@
 
 #include "imx6ull.dtsi"
 #include "imx6ul-14x14-evk.dtsi"
-#include "imx6ul-14x14-evk-u-boot.dtsi"
 
 / {
 	model = "i.MX6 ULL 14x14 EVK Board";


### PR DESCRIPTION
Since we've added our own u-boot dtsi, this isn't needed.
It creates double alias nodes and a lot of wasted space with
alias definitions.

Signed-off-by: Michael Scott <mike@foundries.io>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches
