### PR TITLE
Fix mx6ullevk SPL size overflow

### DIFF
--- a/drivers/usb/host/ehci-mx6.c
+++ b/drivers/usb/host/ehci-mx6.c
@@ -104,7 +104,7 @@ int ehci_hcd_init(int index, enum usb_init_type init,
 	if (index > 3)
 		return -EINVAL;
 
-#if defined(CONFIG_MX6)
+#if defined(CONFIG_MX6) && defined(CONFIG_MODULE_FUSE)
 	if (mx6_usb_fused((u32)ehci)) {
 		printf("USB@0x%x is fused, disable it\n", (u32)ehci);
 		return -ENODEV;

--- a/include/configs/mx6ullevk.h
+++ b/include/configs/mx6ullevk.h
@@ -309,7 +309,9 @@
 #endif
 #endif
 
+#ifndef CONFIG_SPL_BUILD
 #define CONFIG_MODULE_FUSE
 #define CONFIG_OF_SYSTEM_SETUP
+#endif
 
 #endif


### PR DESCRIPTION
- Protect call to mx6_usb_fused() with check for MODULE_FUSE
- Drop MODULE_FUSE and OF_SYSTEM_SETUP from SPL for mx6ullevk